### PR TITLE
chore: atualiza versão do Ares

### DIFF
--- a/docs/latest.json
+++ b/docs/latest.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0-alpha.25",
-    "notes": "https://github.com/ferreira-tb/ares/releases/tag/1.0.0-alpha.25",
-    "download": "https://github.com/ferreira-tb/ares/releases/download/1.0.0-alpha.25/ares-win32-x64-1.0.0-alpha.25.zip"
+    "version": "1.0.0-alpha.26",
+    "notes": "https://github.com/ferreira-tb/ares/releases/tag/1.0.0-alpha.26",
+    "download": "https://github.com/ferreira-tb/ares/releases/download/1.0.0-alpha.26/ares-win32-x64-1.0.0-alpha.26.zip"
 }


### PR DESCRIPTION
Atualizando manualmente pois o workflow falhou.